### PR TITLE
prefer uint8array

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ Use a torrent file buffer as input, and return an object with the following prop
 ```js
 import torrent2magnet from "torrent2magnet-js";
 import fs from "fs";
-import { Buffer } from "buffer";
 
 const torrent_file = fs.readFileSync("./ubuntu.torrent");
-const torrent_file_buffer = Buffer.from(torrent_file);
+const torrent_file_buffer = new Uint8Array(torrent_file); // Buffer.from(torrent_file);
 
 const { success, infohash, magnet_uri, dn, xl, main_tracker, tracker_list, is_private, files } = torrent2magnet(torrent_file_buffer);
 
@@ -64,20 +63,13 @@ import torrent2magnet from "torrent2magnet-js";
     // bencode.decode need ArrayBuffer as input, so we need to use readAsArrayBuffer
     reader.readAsArrayBuffer(file);
     reader.onload = (file: any) => {
-      // bencode need Buffer as input, but Buffer is not exist in native library, so we need to import it and set it as global variable in [polyfills.ts]
-      const buffer_content = Buffer.from(file.target.result);
+      const buffer_content = new Uint8Array(file.target.result);
       const { success, infohash, magnet_uri, dn, xl, main_tracker, tracker_list, is_private, files } = torrent2magnet(buffer_content);
       if (success) {
         //...
       }
     };
 };
-```
-
-```ts
-// polyfills.ts
-import * as buffer from "buffer";
-(window as any).Buffer = buffer.Buffer;
 ```
 
 ## License

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function torrent2magnet(buffer: Buffer): {
+declare function torrent2magnet(buffer: Uint8Array): {
   success: boolean;
   infohash: string;
   magnet_uri: string;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ function response(success = false, infohash = "", magnet_uri = "", dn = "", xl =
 }
 
 function torrent2magnet(buffer_content) {
-  if (!buffer_content || buffer_content instanceof Buffer === false) {
-    console.error("input is not a buffer");
+  if (!buffer_content || buffer_content instanceof Uint8Array === false) {
+    console.error("input is not a Uint8Array");
     return response();
   }
 


### PR DESCRIPTION
The PR replaces `instanceof Buffer` with `instanceof Uint8Array`.

Non-ECMA-262 standard Node.js Buffer is a subclass of `Uint8Array` (an ECMA-262 spec-defined built-in Object). The PR removes the necessary `buffer` polyfill in the browser.

The upstream dependency `bencode` has also dropped `Buffer` and replaced it with `Uint8Array` a year ago: https://github.com/webtorrent/node-bencode/pull/139